### PR TITLE
Addition of individual parameter manipulation for the WhatsApp Unoapi Provider

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -245,6 +245,66 @@
           "PLACEHOLDER": "Check to ignore groups messages.",
           "ERROR": "Check to ignore groups messages."
         },
+        "GENERATE_API_KEY": {
+          "LABEL": "Generate API Key",
+          "PLACEHOLDER": "Generate API Key",
+          "ERROR": "Generate API Key"
+        },
+        "REJECT_CALLS": {
+          "LABEL": "Reject call",
+          "PLACEHOLDER": "Reject call.",
+          "ERROR": "Reject call."
+        },
+        "MESSAGE_CALLS_WEBHOOK": {
+          "LABEL": "Message on reject call",
+          "PLACEHOLDER": "Message on reject call.",
+          "ERROR": "Message on reject call."
+        },
+        "IGNORE_BROADCAST_STATUSES": {
+          "LABEL": "Ignore broadcast statuses",
+          "PLACEHOLDER": "Select to ignore broadcast statuses.",
+          "ERROR": "Select to ignore broadcast statuses."
+        },
+        "IGNORE_BROADCAST_MESSAGES": {
+          "LABEL": "Ignore broadcast messages",
+          "PLACEHOLDER": "Select to ignore broadcast messages.",
+          "ERROR": "Select to ignore broadcast messages."
+        },
+        "IGNORE_OWN_MESSAGES": {
+          "LABEL": "Ignore own messages",
+          "PLACEHOLDER": "Select to ignore own messages.",
+          "ERROR": "Select to ignore own messages."
+        },
+        "IGNORE_YOURSELF_MESSAGES": {
+          "LABEL": "Ignore your messages",
+          "PLACEHOLDER": "Select to ignore your messages.",
+          "ERROR": "Select to ignore your messages."
+        },
+        "SEND_CONNECTION_STATUS": {
+          "LABEL": "Show connection status",
+          "PLACEHOLDER": "Select to show connection status.",
+          "ERROR": "Select to show connection status."
+        },
+        "NOTIFY_FAILED_MESSAGES": {
+          "LABEL": "Notify failed messages",
+          "PLACEHOLDER": "Select to notify failed messages.",
+          "ERROR": "Select to notify failed messages."
+        },
+        "COMPOSING_MESSAGE": {
+          "LABEL": "Compose message",
+          "PLACEHOLDER": "Select to compose message.",
+          "ERROR": "Select to compose message."
+        },
+        "SEND_REACTION_AS_REPLY": {
+          "LABEL": "Show reaction as reply",
+          "PLACEHOLDER": "Select to show reaction as reply.",
+          "ERROR": "Select to show reaction as reply."
+        },
+        "SEND_PROFILE_PICTURE": {
+          "LABEL": "Show profile picture",
+          "PLACEHOLDER": "Select to show profile picture.",
+          "ERROR": "Select to show profile picture."
+        },        
         "URL": {
           "LABEL": "Unoapi URL",
           "PLACEHOLDER": "Please enter an Unoapi URL or use default https://unoapi.cloud",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/inboxMgmt.json
@@ -243,6 +243,71 @@
           "PLACEHOLDER": "Por favor, digite um nome para caixa de entrada",
           "ERROR": "Este campo é obrigatório"
         },
+        "GENERATE_API_KEY": {
+          "LABEL": "Generate API Key",
+          "PLACEHOLDER": "Generate API Key",
+          "ERROR": "Generate API Key"
+        },
+        "REJECT_CALLS": {
+          "LABEL": "Rejeitar chamada",
+          "PLACEHOLDER": "Rejeitar chamada.",
+          "ERROR": "Rejeitar chamada."
+        },
+        "MESSAGE_CALLS_WEBHOOK": {
+          "LABEL": "Mensagem ao rejeitar chamada",
+          "PLACEHOLDER": "Mensagem ao rejeitar chamada.",
+          "ERROR": "Mensagem ao rejeitar chamada."
+        },
+        "IGNORE_BROADCAST_STATUSES": {
+          "LABEL": "Ignorar transmissão de status",
+          "PLACEHOLDER": "Selecione para ignorar transmissão de status.",
+          "ERROR": "Selecione para ignorar transmissão de status."
+        },
+        "IGNORE_BROADCAST_MESSAGES": {
+          "LABEL": "Ignorar mensagens de transmissão",
+          "PLACEHOLDER": "Selecione para ignorar mensagens de transmissão.",
+          "ERROR": "Selecione para ignorar mensagens de transmissão."
+        },
+        "IGNORE_OWN_MESSAGES": {
+          "LABEL": "Ignorar próprias mensagens",
+          "PLACEHOLDER": "Selecione para ignorar próprias mensagens.",
+          "ERROR": "Selecione para ignorar próprias mensagens."
+        },
+        "IGNORE_YOURSELF_MESSAGES": {
+          "LABEL": "Ignorar suas mensagens",
+          "PLACEHOLDER": "Selecione para ignorar suas mensagens.",
+          "ERROR": "Selecione para ignorar suas mensagens."
+        },
+        "SEND_CONNECTION_STATUS": {
+          "LABEL": "Exibir status de conexão",
+          "PLACEHOLDER": "Selecione para exibir status de conexão.",
+          "ERROR": "Selecione para exibir status de conexão."
+        },
+        "NOTIFY_FAILED_MESSAGES": {
+          "LABEL": "Notificar mensagens com falha",
+          "PLACEHOLDER": "Selecione para notificar mensagens com falha.",
+          "ERROR": "Selecione para notificar mensagens com falha."
+        },
+        "COMPOSING_MESSAGE": {
+          "LABEL": "Compor mensagem",
+          "PLACEHOLDER": "Selecione para compor mensagem.",
+          "ERROR": "Selecione para compor mensagem."
+        },
+        "SEND_REACTION_AS_REPLY": {
+          "LABEL": "Mostrar reação como resposta",
+          "PLACEHOLDER": "Selecione para mostrar reação como resposta.",
+          "ERROR": "Selecione para mostrar reação como resposta."
+        },
+        "SEND_PROFILE_PICTURE": {
+          "LABEL": "Exibir foto de perfil",
+          "PLACEHOLDER": "Selecione para exibir foto de perfil.",
+          "ERROR": "Selecione para exibir foto de perfil."
+        },
+        "URL": {
+          "LABEL": "Unoapi URL",
+          "PLACEHOLDER": "Insira um URL Unoapi",
+          "ERROR": "Este campo é obrigatório"
+        },        
         "PHONE_NUMBER": {
           "LABEL": "Número de telefone",
           "PLACEHOLDER": "Por favor, insira o número de telefone do qual a mensagem será enviada.",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Unoapi.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Unoapi.vue
@@ -108,13 +108,32 @@
         </span>
       </label>
     </div>
-
+    
+    <div class="w-[65%] flex-shrink-0 flex-grow-0 max-w-[65%] config-helptext">
+      <label :class="{ error: $v.webhookSendNewMessages.$error }" style="display: flex; align-items: center;">
+        <woot-switch
+          v-model="webhookSendNewMessages"
+          :value="webhookSendNewMessages"
+          style="flex: 0 0 auto; margin-right: 10px;"
+        />
+        {{ $t('INBOX_MGMT.ADD.WHATSAPP.WEBWOOK_SEND_NEW_MESSAGES.LABEL') }}
+        <span v-if="$v.webhookSendNewMessages.$error" class="message">
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.WEBWOOK_SEND_NEW_MESSAGES.ERROR') }}
+        </span>
+      </label>
+    </div>
+    
     <div class="w-full" style="margin-top: 20px">
       <woot-submit-button
         :loading="uiFlags.isCreating"
         :button-text="$t('INBOX_MGMT.ADD.WHATSAPP.SUBMIT_BUTTON')"
       />
-    </div>
+      <woot-submit-button
+        :loading="uiFlags.isUpdating"          
+        :button-text="$t('INBOX_MGMT.ADD.WHATSAPP.GENERATE_API_KEY.LABEL')"
+        @click="generateToken"
+      /> 
+    </div>    
   </form>
 </template>
 
@@ -136,6 +155,7 @@ export default {
       ignoreGroupMessages: true,
       ignoreHistoryMessages: true,
       sendAgentName: true,
+      webhookSendNewMessages: true,
     };
   },
   computed: {
@@ -148,9 +168,25 @@ export default {
     ignoreGroupMessages: { required },
     ignoreHistoryMessages: { required },
     sendAgentName: { required },
+    webhookSendNewMessages: { required },
     url: { required },
   },
   methods: {
+    generateToken() {
+      const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+      let token = '';
+      for (let i = 0; i < 64; i++) {
+        token += characters.charAt(Math.floor(Math.random() * characters.length));
+      }
+
+      if (this.apiKey) {
+        if (confirm('A token already exists. Do you want to replace it?')) {
+          this.apiKey = token;
+        }
+      } else {
+        this.apiKey = token;
+      }
+    },
     async createChannel() {
       this.$v.$touch();
       if (this.$v.$invalid) {
@@ -174,6 +210,7 @@ export default {
                 ignore_history_messages: this.ignoreHistoryMessages,
                 ignore_group_messages: this.ignoreGroupMessages,
                 send_agent_name: this.sendAgentName,
+                webhook_send_new_messages: this.webhookSendNewMessages,
                 url: this.url,
               },
             },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/UnoapiConfiguration.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/UnoapiConfiguration.vue
@@ -331,7 +331,7 @@ export default {
       sendAgentName: true,
       ignoreBroadcastStatuses: true,
       ignoreBroadcastMessages: true,
-      ignoreOwnMessages: false,
+      ignoreOwnMessages: true,
       ignoreYourselfMessages: true,
       sendConnectionStatus: true,
       notifyFailedMessages: true,

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/UnoapiConfiguration.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/UnoapiConfiguration.vue
@@ -3,11 +3,14 @@
     <form class="flex flex-col" @submit.prevent="updateInbox()">
       <div class="w-1/4">
         <label :class="{ error: $v.url.$error }">
-          {{ $t('INBOX_MGMT.ADD.WHATSAPP.URL.LABEL') }}
+          <span>
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.URL.LABEL') }}
+          </span>
           <input
             v-model.trim="url"
             type="text"
-            placeholder="$t('INBOX_MGMT.ADD.WHATSAPP.URL.PLACEHOLDER')"
+            :placeholder="$t('INBOX_MGMT.ADD.WHATSAPP.URL.PLACEHOLDER')"
+            @blur="$v.url.$touch"
           />
           <span v-if="$v.url.$error" class="message">
             {{ $t('INBOX_MGMT.ADD.WHATSAPP.URL.ERROR') }}
@@ -32,6 +35,40 @@
         </label>
       </div>
 
+      <div class="w-1/4">
+        <label :class="{ error: $v.rejectCalls.$error }">
+          <span>
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.REJECT_CALLS.LABEL') }}
+          </span>
+          <input
+            v-model.trim="rejectCalls"
+            type="text"
+            :placeholder="$t('INBOX_MGMT.ADD.WHATSAPP.REJECT_CALLS.PLACEHOLDER')"
+            @blur="$v.rejectCalls.$touch"
+          />
+          <span v-if="$v.rejectCalls.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.REJECT_CALLS.ERROR') }}
+          </span>
+        </label>
+      </div>
+
+      <div class="w-1/4">
+        <label :class="{ error: $v.messageCallsWebhook.$error }">
+          <span>
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.MESSAGE_CALLS_WEBHOOK.LABEL') }}
+          </span>
+          <input
+            v-model.trim="messageCallsWebhook"
+            type="text"
+            :placeholder="$t('INBOX_MGMT.ADD.WHATSAPP.MESSAGE_CALLS_WEBHOOK.PLACEHOLDER')"
+            @blur="$v.messageCallsWebhook.$touch"
+          />
+          <span v-if="$v.messageCallsWebhook.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.MESSAGE_CALLS_WEBHOOK.ERROR') }}
+          </span>
+        </label>
+      </div>      
+      
       <div class="w-3/4 pb-4 config-helptext">
         <label
           :class="'switch-label ' + { error: $v.sendAgentName.$error }"
@@ -97,6 +134,150 @@
       </div>
 
       <div class="w-3/4 pb-4 config-helptext">
+        <label
+          :class="'switch-label ' + { error: $v.ignoreBroadcastStatuses.$error }"
+        >
+          <woot-switch
+            v-model="ignoreBroadcastStatuses"
+            :value="ignoreBroadcastStatuses"
+            class="switch"
+          />
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.IGNORE_BROADCAST_STATUSES.LABEL') }}
+          <span v-if="$v.ignoreBroadcastStatuses.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.IGNORE_BROADCAST_STATUSES.ERROR') }}
+          </span>
+        </label>
+      </div>
+
+      <div class="w-3/4 pb-4 config-helptext">
+        <label
+          :class="'switch-label ' + { error: $v.ignoreBroadcastMessages.$error }"
+        >
+          <woot-switch
+            v-model="ignoreBroadcastMessages"
+            :value="ignoreBroadcastMessages"
+            class="switch"
+          />
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.IGNORE_BROADCAST_MESSAGES.LABEL') }}
+          <span v-if="$v.ignoreBroadcastMessages.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.IGNORE_BROADCAST_MESSAGES.ERROR') }}
+          </span>
+        </label>
+      </div>
+
+      <div class="w-3/4 pb-4 config-helptext">
+        <label
+          :class="'switch-label ' + { error: $v.ignoreOwnMessages.$error }"
+        >
+          <woot-switch
+            v-model="ignoreOwnMessages"
+            :value="ignoreOwnMessages"
+            class="switch"
+          />
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.IGNORE_OWN_MESSAGES.LABEL') }}
+          <span v-if="$v.ignoreOwnMessages.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.IGNORE_OWN_MESSAGES.ERROR') }}
+          </span>
+        </label>
+      </div>
+
+      <div class="w-3/4 pb-4 config-helptext">
+        <label
+          :class="'switch-label ' + { error: $v.ignoreYourselfMessages.$error }"
+        >
+          <woot-switch
+            v-model="ignoreYourselfMessages"
+            :value="ignoreYourselfMessages"
+            class="switch"
+          />
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.IGNORE_YOURSELF_MESSAGES.LABEL') }}
+          <span v-if="$v.ignoreYourselfMessages.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.IGNORE_YOURSELF_MESSAGES.ERROR') }}
+          </span>
+        </label>
+      </div>
+
+      <div class="w-3/4 pb-4 config-helptext">
+        <label
+          :class="'switch-label ' + { error: $v.sendConnectionStatus.$error }"
+        >
+          <woot-switch
+            v-model="sendConnectionStatus"
+            :value="sendConnectionStatus"
+            class="switch"
+          />
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.SEND_CONNECTION_STATUS.LABEL') }}
+          <span v-if="$v.sendConnectionStatus.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.SEND_CONNECTION_STATUS.ERROR') }}
+          </span>
+        </label>
+      </div>
+
+      <div class="w-3/4 pb-4 config-helptext">
+        <label
+          :class="'switch-label ' + { error: $v.notifyFailedMessages.$error }"
+        >
+          <woot-switch
+            v-model="notifyFailedMessages"
+            :value="notifyFailedMessages"
+            class="switch"
+          />
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.NOTIFY_FAILED_MESSAGES.LABEL') }}
+          <span v-if="$v.notifyFailedMessages.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.NOTIFY_FAILED_MESSAGES.ERROR') }}
+          </span>
+        </label>
+      </div>
+
+      <div class="w-3/4 pb-4 config-helptext">
+        <label
+          :class="'switch-label ' + { error: $v.composingMessage.$error }"
+        >
+          <woot-switch
+            v-model="composingMessage"
+            :value="composingMessage"
+            class="switch"
+          />
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.COMPOSING_MESSAGE.LABEL') }}
+          <span v-if="$v.composingMessage.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.COMPOSING_MESSAGE.ERROR') }}
+          </span>
+        </label>
+      </div>
+
+      <div class="w-3/4 pb-4 config-helptext">
+        <label
+          :class="'switch-label ' + { error: $v.sendReactionAsReply.$error }"
+        >
+          <woot-switch
+            v-model="sendReactionAsReply"
+            :value="sendReactionAsReply"
+            class="switch"
+          />
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.SEND_REACTION_AS_REPLY.LABEL') }}
+          <span v-if="$v.sendReactionAsReply.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.SEND_REACTION_AS_REPLY.ERROR') }}
+          </span>
+        </label>
+      </div>
+
+      <div class="w-3/4 pb-4 config-helptext">
+        <label
+          :class="'switch-label ' + { error: $v.sendProfilePicture.$error }"
+        >
+          <woot-switch
+            v-model="sendProfilePicture"
+            :value="sendProfilePicture"
+            class="switch"
+          />
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.SEND_PROFILE_PICTURE.LABEL') }}
+          <span v-if="$v.sendProfilePicture.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.SEND_PROFILE_PICTURE.ERROR') }}
+          </span>
+        </label>
+      </div>      
+      
+      <div class="w-3/4 pb-4 config-helptext">
         <img v-if="qrcode" :src="qrcode" />
         <div v-if="notice">{{ notice }}</div>
       </div>
@@ -109,11 +290,16 @@
           )} and ${$t('INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_CONNECT')}`"
           @click="connect = true"
         />
-        <!-- <woot-submit-button
-        :loading="uiFlags.isUpdating"
-        :button-text="$t('INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_DISCONNECT')"
-        @click="disconnect = true"
-      /> -->
+        <woot-submit-button
+          :loading="uiFlags.isUpdating"
+          :button-text="$t('INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_DISCONNECT')"
+          @click="disconnect = true"
+        />
+        <woot-submit-button
+          :loading="uiFlags.isUpdating"          
+          :button-text="$t('INBOX_MGMT.ADD.WHATSAPP.GENERATE_API_KEY.LABEL')"
+          @click="generateToken"
+        />
       </div>
     </form>
   </div>
@@ -143,10 +329,21 @@ export default {
       ignoreHistoryMessages: true,
       webhookSendNewMessages: true,
       sendAgentName: true,
+      ignoreBroadcastStatuses: true,
+      ignoreBroadcastMessages: true,
+      ignoreOwnMessages: true,
+      ignoreYourselfMessages: true,
+      sendConnectionStatus: true,
+      notifyFailedMessages: true,
+      composingMessage: true,
+      sendReactionAsReply: true,
+      sendProfilePicture: true,       
       connect: false,
       disconect: false,
       qrcode: '',
       notice: '',
+      rejectCalls: '',
+      messageCallsWebhook: '',      
     };
   },
   computed: {
@@ -160,6 +357,17 @@ export default {
     webhookSendNewMessages: { required },
     sendAgentName: { required },
     url: { required },
+    ignoreBroadcastStatuses: { required },
+    ignoreBroadcastMessages: { required },
+    ignoreOwnMessages: { required },
+    ignoreYourselfMessages: { required },
+    sendConnectionStatus: { required },
+    notifyFailedMessages: { required },
+    composingMessage: { required },
+    sendReactionAsReply: { required },
+    sendProfilePicture: { required },
+    rejectCalls: { required },
+    messageCallsWebhook: { required },
   },
   watch: {
     inbox() {
@@ -174,13 +382,21 @@ export default {
     setDefaults() {
       this.apiKey = this.inbox.provider_config.api_key;
       this.url = this.inbox.provider_config.url;
-      this.ignoreGroupMessages =
-        this.inbox.provider_config.ignore_group_messages;
-      this.ignoreHistoryMessages =
-        this.inbox.provider_config.ignore_history_messages;
-      this.webhookSendNewMessages =
-        this.inbox.provider_config.webhook_send_new_messages;
+      this.ignoreGroupMessages = this.inbox.provider_config.ignore_group_messages;
+      this.ignoreHistoryMessages = this.inbox.provider_config.ignore_history_messages;
+      this.webhookSendNewMessages = this.inbox.provider_config.webhook_send_new_messages;
       this.sendAgentName = this.inbox.provider_config.send_agent_name;
+      this.ignoreBroadcastStatuses = this.inbox.provider_config.ignore_Broadcast_Statuses;
+      this.ignoreBroadcastMessages = this.inbox.provider_config.ignore_Broadcast_Messages;
+      this.ignoreOwnMessages = this.inbox.provider_config.ignore_Own_Messages;
+      this.ignoreYourselfMessages = this.inbox.provider_config.ignore_Yourself_Messages;
+      this.sendConnectionStatus = this.inbox.provider_config.send_Connection_Status;
+      this.notifyFailedMessages = this.inbox.provider_config.notify_Failed_Messages;
+      this.composingMessage = this.inbox.provider_config.composing_Message;
+      this.sendReactionAsReply = this.inbox.provider_config.send_Reaction_As_Reply;
+      this.sendProfilePicture = this.inbox.provider_config.send_Profile_Picture;
+      this.rejectCalls = this.inbox.provider_config.reject_Calls;
+      this.messageCallsWebhook = this.inbox.provider_config.message_Calls_Webhook;
       this.connect = false;
       this.disconect = false;
     },
@@ -223,6 +439,21 @@ export default {
       //   }
       // );
     },
+    generateToken() {
+      const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+      let token = '';
+      for (let i = 0; i < 64; i++) {
+        token += characters.charAt(Math.floor(Math.random() * characters.length));
+      }
+
+      if (this.apiKey) {
+        if (confirm('A token already exists. Do you want to replace it?')) {
+          this.apiKey = token;
+        }
+      } else {
+        this.apiKey = token;
+      }
+    },
     async updateInbox() {
       try {
         const payload = {
@@ -237,6 +468,18 @@ export default {
               send_agent_name: this.sendAgentName,
               webhook_send_new_messages: this.webhookSendNewMessages,
               url: this.url,
+              webhook_send_new_messages: this.webhookSendNewMessages,
+              ignore_Broadcast_Statuses: this.ignoreBroadcastStatuses,
+              ignore_Broadcast_Messages: this.ignoreBroadcastMessages,
+              ignore_Own_Messages: this.ignoreOwnMessages,
+              ignore_Yourself_Messages: this.ignoreYourselfMessages,
+              send_Connection_Status: this.sendConnectionStatus,
+              notify_Failed_Messages: this.notifyFailedMessages,
+              composing_Message: this.composingMessage,
+              send_Reaction_As_Reply: this.sendReactionAsReply,
+              send_Profile_Picture: this.sendProfilePicture,
+              reject_Calls: this.rejectCalls,
+              message_Calls_Webhook: this.messageCallsWebhook,              
               connect: this.connect,
               disconect: this.disconect,
             },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/UnoapiConfiguration.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/UnoapiConfiguration.vue
@@ -331,7 +331,7 @@ export default {
       sendAgentName: true,
       ignoreBroadcastStatuses: true,
       ignoreBroadcastMessages: true,
-      ignoreOwnMessages: true,
+      ignoreOwnMessages: false,
       ignoreYourselfMessages: true,
       sendConnectionStatus: true,
       notifyFailedMessages: true,
@@ -386,17 +386,17 @@ export default {
       this.ignoreHistoryMessages = this.inbox.provider_config.ignore_history_messages;
       this.webhookSendNewMessages = this.inbox.provider_config.webhook_send_new_messages;
       this.sendAgentName = this.inbox.provider_config.send_agent_name;
-      this.ignoreBroadcastStatuses = this.inbox.provider_config.ignore_Broadcast_Statuses;
-      this.ignoreBroadcastMessages = this.inbox.provider_config.ignore_Broadcast_Messages;
-      this.ignoreOwnMessages = this.inbox.provider_config.ignore_Own_Messages;
-      this.ignoreYourselfMessages = this.inbox.provider_config.ignore_Yourself_Messages;
-      this.sendConnectionStatus = this.inbox.provider_config.send_Connection_Status;
-      this.notifyFailedMessages = this.inbox.provider_config.notify_Failed_Messages;
-      this.composingMessage = this.inbox.provider_config.composing_Message;
-      this.sendReactionAsReply = this.inbox.provider_config.send_Reaction_As_Reply;
-      this.sendProfilePicture = this.inbox.provider_config.send_Profile_Picture;
-      this.rejectCalls = this.inbox.provider_config.reject_Calls;
-      this.messageCallsWebhook = this.inbox.provider_config.message_Calls_Webhook;
+      this.ignoreBroadcastStatuses = this.inbox.provider_config.ignore_broadcast_statuses;
+      this.ignoreBroadcastMessages = this.inbox.provider_config.ignore_broadcast_messages;
+      this.ignoreOwnMessages = this.inbox.provider_config.ignore_own_messages;
+      this.ignoreYourselfMessages = this.inbox.provider_config.ignore_yourself_messages;
+      this.sendConnectionStatus = this.inbox.provider_config.send_connection_status;
+      this.notifyFailedMessages = this.inbox.provider_config.notify_failed_messages;
+      this.composingMessage = this.inbox.provider_config.composing_message;
+      this.sendReactionAsReply = this.inbox.provider_config.send_reaction_as_reply;
+      this.sendProfilePicture = this.inbox.provider_config.send_profile_picture;
+      this.rejectCalls = this.inbox.provider_config.reject_calls;
+      this.messageCallsWebhook = this.inbox.provider_config.message_calls_webhook;
       this.connect = false;
       this.disconect = false;
     },
@@ -469,17 +469,17 @@ export default {
               webhook_send_new_messages: this.webhookSendNewMessages,
               url: this.url,
               webhook_send_new_messages: this.webhookSendNewMessages,
-              ignore_Broadcast_Statuses: this.ignoreBroadcastStatuses,
-              ignore_Broadcast_Messages: this.ignoreBroadcastMessages,
-              ignore_Own_Messages: this.ignoreOwnMessages,
-              ignore_Yourself_Messages: this.ignoreYourselfMessages,
-              send_Connection_Status: this.sendConnectionStatus,
-              notify_Failed_Messages: this.notifyFailedMessages,
-              composing_Message: this.composingMessage,
-              send_Reaction_As_Reply: this.sendReactionAsReply,
-              send_Profile_Picture: this.sendProfilePicture,
-              reject_Calls: this.rejectCalls,
-              message_Calls_Webhook: this.messageCallsWebhook,              
+              ignore_broadcast_statuses: this.ignoreBroadcastStatuses,
+              ignore_broadcast_messages: this.ignoreBroadcastMessages,
+              ignore_own_messages: this.ignoreOwnMessages,
+              ignore_yourself_messages: this.ignoreYourselfMessages,
+              send_connection_status: this.sendConnectionStatus,
+              notify_failed_messages: this.notifyFailedMessages,
+              composing_message: this.composingMessage,
+              send_reaction_as_reply: this.sendReactionAsReply,
+              send_profile_picture: this.sendProfilePicture,
+              reject_calls: this.rejectCalls,
+              message_calls_Webhook: this.messageCallsWebhook,              
               connect: this.connect,
               disconect: this.disconect,
             },

--- a/app/services/whatsapp/unoapi_webhook_setup_service.rb
+++ b/app/services/whatsapp/unoapi_webhook_setup_service.rb
@@ -25,16 +25,16 @@ class Whatsapp::UnoapiWebhookSetupService
     Rails.logger.debug { "Connecting #{phone_number} from unoapi" }
     body = {
       ignoreGroupMessages: whatsapp_channel.provider_config['ignore_group_messages'],
-      ignoreBroadcastStatuses: whatsapp_channel.provider_config['ignore_Broadcast_Statuses'],
-      ignoreBroadcastMessages: whatsapp_channel.provider_config['ignore_Broadcast_Messages'],
+      ignoreBroadcastStatuses: whatsapp_channel.provider_config['ignore_broadcast_statuses'],
+      ignoreBroadcastMessages: whatsapp_channel.provider_config['ignore_broadcast_messages'],
       ignoreHistoryMessages: whatsapp_channel.provider_config['ignore_history_messages'],
-      ignoreOwnMessages: whatsapp_channel.provider_config['ignore_Own_Messages'],
-      ignoreYourselfMessages: whatsapp_channel.provider_config['ignore_Yourself_Messages'],
-      sendConnectionStatus: whatsapp_channel.provider_config['send_Connection_Status'],
-      notifyFailedMessages: whatsapp_channel.provider_config['notify_Failed_Messages'],
-      composingMessage: whatsapp_channel.provider_config['composing_Message'],
-      rejectCalls: whatsapp_channel.provider_config['reject_Calls'],
-      messageCallsWebhook: whatsapp_channel.provider_config['message_Calls_Webhook'],
+      ignoreOwnMessages: whatsapp_channel.provider_config['ignore_own_messages'],
+      ignoreYourselfMessages: whatsapp_channel.provider_config['ignore_yourself_messages'],
+      sendConnectionStatus: whatsapp_channel.provider_config['send_connection_status'],
+      notifyFailedMessages: whatsapp_channel.provider_config['notify_failed_messages'],
+      composingMessage: whatsapp_channel.provider_config['composing_message'],
+      rejectCalls: whatsapp_channel.provider_config['reject_calls'],
+      messageCallsWebhook: whatsapp_channel.provider_config['message_calls_webhook'],
       webhooks: [
         sendNewMessages: whatsapp_channel.provider_config['webhook_send_new_messages'],
         id: 'default',
@@ -42,8 +42,8 @@ class Whatsapp::UnoapiWebhookSetupService
         token: whatsapp_channel.provider_config['webhook_verify_token'],
         header: :Authorization
       ],
-      sendReactionAsReply: whatsapp_channel.provider_config['send_Reaction_As_Reply'],
-      sendProfilePicture: whatsapp_channel.provider_config['send_Profile_Picture'],      
+      sendReactionAsReply: whatsapp_channel.provider_config['send_reaction_as_reply'],
+      sendProfilePicture: whatsapp_channel.provider_config['send_profile_picture'],      
       authToken: whatsapp_channel.provider_config['api_key']
     }
     response = HTTParty.post("#{url(whatsapp_channel)}/register", headers: headers(whatsapp_channel), body: body.to_json)

--- a/app/services/whatsapp/unoapi_webhook_setup_service.rb
+++ b/app/services/whatsapp/unoapi_webhook_setup_service.rb
@@ -24,6 +24,17 @@ class Whatsapp::UnoapiWebhookSetupService
     phone_number = whatsapp_channel.provider_config['business_account_id']
     Rails.logger.debug { "Connecting #{phone_number} from unoapi" }
     body = {
+      ignoreGroupMessages: whatsapp_channel.provider_config['ignore_group_messages'],
+      ignoreBroadcastStatuses: whatsapp_channel.provider_config['ignore_Broadcast_Statuses'],
+      ignoreBroadcastMessages: whatsapp_channel.provider_config['ignore_Broadcast_Messages'],
+      ignoreHistoryMessages: whatsapp_channel.provider_config['ignore_history_messages'],
+      ignoreOwnMessages: whatsapp_channel.provider_config['ignore_Own_Messages'],
+      ignoreYourselfMessages: whatsapp_channel.provider_config['ignore_Yourself_Messages'],
+      sendConnectionStatus: whatsapp_channel.provider_config['send_Connection_Status'],
+      notifyFailedMessages: whatsapp_channel.provider_config['notify_Failed_Messages'],
+      composingMessage: whatsapp_channel.provider_config['composing_Message'],
+      rejectCalls: whatsapp_channel.provider_config['reject_Calls'],
+      messageCallsWebhook: whatsapp_channel.provider_config['message_Calls_Webhook'],
       webhooks: [
         sendNewMessages: whatsapp_channel.provider_config['webhook_send_new_messages'],
         id: 'default',
@@ -31,8 +42,8 @@ class Whatsapp::UnoapiWebhookSetupService
         token: whatsapp_channel.provider_config['webhook_verify_token'],
         header: :Authorization
       ],
-      ignoreGroupMessages: whatsapp_channel.provider_config['ignore_group_messages'],
-      ignoreHistoryMessages: whatsapp_channel.provider_config['ignore_history_messages'],
+      sendReactionAsReply: whatsapp_channel.provider_config['send_Reaction_As_Reply'],
+      sendProfilePicture: whatsapp_channel.provider_config['send_Profile_Picture'],      
       authToken: whatsapp_channel.provider_config['api_key']
     }
     response = HTTParty.post("#{url(whatsapp_channel)}/register", headers: headers(whatsapp_channel), body: body.to_json)


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes the addition of individual parameter manipulation for the WhatsApp Unoapi Provider. The parameters added include:

- Reject call
- Message when rejecting call
- Send agent name
- Ignore group messages
- Ignore history on connect
- Send messages to webhook
- Ignore status broadcast
- Ignore broadcast messages
- Ignore own messages
- Ignore your messages
- Show connection status
- Notify messages with failure
- Compose message
- Show reaction as a reply
- Display profile picture
- Generate API Key

Files altered:
- `app/javascript/dashboard/i18n/locale/en/inboxMgmt.json`
- `app/javascript/dashboard/i18n/locale/pt_BR/inboxMgmt.json`
- `app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Unoapi.vue`
- `app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/UnoapiConfiguration.vue`
- `app/services/whatsapp/unoapi_webhook_setup_service.rb`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- Unit tests were added to cover the new parameters.
- Manual testing was conducted to verify the correct behavior of each parameter in different scenarios.
- End-to-end testing was performed to ensure integration with the Unoapi Provider works as expected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
